### PR TITLE
Add total duration calculations for tasks

### DIFF
--- a/commands/task.go
+++ b/commands/task.go
@@ -69,10 +69,14 @@ func init() {
 				return false
 			}
 
+			// Filter incomplete tasks for duration calculation
+			var incompleteTasks []*storage.Task
 			for _, t := range tasks {
 				status := "[ ]"
 				if t.Done {
 					status = "[✓]"
+				} else {
+					incompleteTasks = append(incompleteTasks, t)
 				}
 
 				// Build extra info string
@@ -90,6 +94,12 @@ func init() {
 				}
 
 				fmt.Printf("  %s [%s] %s%s\n", status, t.ID, t.Name, extraStr)
+			}
+
+			// Show total duration for incomplete tasks
+			totalMinutes := storage.TotalDuration(incompleteTasks)
+			if totalMinutes > 0 {
+				fmt.Printf("\nTotal: %s\n", storage.FormatMinutes(totalMinutes))
 			}
 
 			return false

--- a/storage/types.go
+++ b/storage/types.go
@@ -1,6 +1,9 @@
 package storage
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // Duration represents a task duration
 type Duration string
@@ -24,6 +27,49 @@ func IsValidDuration(s string) bool {
 		}
 	}
 	return false
+}
+
+// ToMinutes converts a Duration to minutes
+func (d Duration) ToMinutes() int {
+	switch d {
+	case Duration15m:
+		return 15
+	case Duration30m:
+		return 30
+	case Duration1h:
+		return 60
+	case Duration2h:
+		return 120
+	case Duration4h:
+		return 240
+	default:
+		return 0
+	}
+}
+
+// FormatMinutes formats a number of minutes as a human-readable string (e.g., "2h 30m")
+func FormatMinutes(minutes int) string {
+	if minutes == 0 {
+		return "0m"
+	}
+	hours := minutes / 60
+	mins := minutes % 60
+	if hours == 0 {
+		return fmt.Sprintf("%dm", mins)
+	}
+	if mins == 0 {
+		return fmt.Sprintf("%dh", hours)
+	}
+	return fmt.Sprintf("%dh %dm", hours, mins)
+}
+
+// TotalDuration calculates the total duration in minutes for a slice of tasks
+func TotalDuration(tasks []*Task) int {
+	total := 0
+	for _, t := range tasks {
+		total += t.Duration.ToMinutes()
+	}
+	return total
 }
 
 // Project represents a parent container for tasks


### PR DESCRIPTION
## Summary
- Add `ToMinutes()` method on Duration type to convert durations to minutes
- Add `FormatMinutes()` function to format minutes as human-readable string (e.g., "2h 30m")
- Add `TotalDuration()` function to sum task durations from a slice
- Update `/tasks` command to show total duration for incomplete tasks

## Example Output
```
Tasks in My Project:
  [ ] [task-1] Write docs (1h)
  [ ] [task-2] Review PR (30m)
  [✓] [task-3] Fix bug (15m)

Total: 1h 30m
```

## Test plan
- [x] Create a project with tasks that have durations set
- [x] Run `/tasks <project-id>` and verify total is shown
- [x] Mark some tasks as done and verify only incomplete tasks are summed
- [x] Verify formatting works correctly (e.g., "30m", "1h", "2h 30m")

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)