### PR TITLE
Highlight overdue tasks and include them in /today command

### DIFF
--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -19,6 +19,9 @@ func TestGenerateToolDefinitions(t *testing.T) {
 		"deltask":    true,
 		"due":        true,
 		"duration":   true,
+		"today":      true,
+		"tomorrow":   true,
+		"week":       true,
 	}
 
 	// Commands that should NOT be generated (hidden)

--- a/commands/task.go
+++ b/commands/task.go
@@ -93,7 +93,12 @@ func init() {
 					extraStr = " (" + strings.Join(extras, ", ") + ")"
 				}
 
-				fmt.Printf("  %s [%s] %s%s\n", status, t.ID, t.Name, extraStr)
+				// Highlight overdue tasks in red
+				if isOverdue(t) {
+					fmt.Printf("  %s%s [%s] %s%s%s\n", colorRed, status, t.ID, t.Name, extraStr, colorReset)
+				} else {
+					fmt.Printf("  %s [%s] %s%s\n", status, t.ID, t.Name, extraStr)
+				}
 			}
 
 			// Show total duration for incomplete tasks


### PR DESCRIPTION
## Summary
- Add red ANSI color highlighting for overdue tasks (tasks with due date before today that aren't done)
- Apply highlighting in both `/tasks` and date range commands (`/today`, `/tomorrow`, `/week`)
- Update `/today` to include overdue tasks alongside today's tasks

Closes #32, closes #33

## Test plan
- [x] Create a task with a due date in the past
- [x] Run `/tasks <project-id>` and verify the overdue task appears in red
- [x] Run `/today` and verify overdue tasks appear at the top, highlighted in red
- [x] Run `/tomorrow` and `/week` to verify they don't include overdue tasks but would highlight them if applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)