### PR TITLE
Replace sequential IDs with UUIDs and add project shortcuts

### DIFF
--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -12,6 +12,7 @@ func TestGenerateToolDefinitions(t *testing.T) {
 		"project":    true,
 		"projects":   true,
 		"delproject": true,
+		"shortcut":   true,
 		"task":       true,
 		"tasks":      true,
 		"done":       true,

--- a/commands/project.go
+++ b/commands/project.go
@@ -25,7 +25,7 @@ func init() {
 				return false
 			}
 
-			fmt.Printf("Created project: %s (ID: %s)\n", project.Name, project.ID)
+			fmt.Printf("Created project: %s (shortcut: %s)\n", project.Name, project.Shortcut)
 			return false
 		},
 	})
@@ -57,7 +57,7 @@ func init() {
 				}
 
 				fmt.Printf("  [%s] %s (%d/%d tasks complete)\n",
-					p.ID, p.Name, done, len(tasks))
+					p.Shortcut, p.Name, done, len(tasks))
 			}
 
 			return false
@@ -76,13 +76,28 @@ func init() {
 				return false
 			}
 
-			projectID := args[0]
+			projectRef := args[0]
+
+			// Resolve project ID
+			projectID, err := GetStore().ResolveProjectID(projectRef)
+			if err != nil {
+				fmt.Printf("Error: %v\n", err)
+				return false
+			}
+
+			// Get project for display
+			project, err := GetStore().GetProject(projectID)
+			if err != nil {
+				fmt.Printf("Error: %v\n", err)
+				return false
+			}
+
 			if err := GetStore().DeleteProject(projectID); err != nil {
 				fmt.Printf("Error deleting project: %v\n", err)
 				return false
 			}
 
-			fmt.Printf("Deleted project: %s\n", projectID)
+			fmt.Printf("Deleted project: %s\n", project.Name)
 			return false
 		},
 	})

--- a/commands/schedule.go
+++ b/commands/schedule.go
@@ -34,7 +34,13 @@ func init() {
 		Handler: func(args []string) bool {
 			var projectID string
 			if len(args) > 0 {
-				projectID = args[0]
+				// Resolve project ID
+				resolved, err := GetStore().ResolveProjectID(args[0])
+				if err != nil {
+					fmt.Printf("Error: %v\n", err)
+					return false
+				}
+				projectID = resolved
 			}
 
 			today := dateOnly(time.Now())
@@ -54,7 +60,13 @@ func init() {
 		Handler: func(args []string) bool {
 			var projectID string
 			if len(args) > 0 {
-				projectID = args[0]
+				// Resolve project ID
+				resolved, err := GetStore().ResolveProjectID(args[0])
+				if err != nil {
+					fmt.Printf("Error: %v\n", err)
+					return false
+				}
+				projectID = resolved
 			}
 
 			today := dateOnly(time.Now())
@@ -75,7 +87,13 @@ func init() {
 		Handler: func(args []string) bool {
 			var projectID string
 			if len(args) > 0 {
-				projectID = args[0]
+				// Resolve project ID
+				resolved, err := GetStore().ResolveProjectID(args[0])
+				if err != nil {
+					fmt.Printf("Error: %v\n", err)
+					return false
+				}
+				projectID = resolved
 			}
 
 			today := dateOnly(time.Now())
@@ -183,11 +201,14 @@ func listTasksInRange(label string, start, end time.Time, projectID string, incl
 			extraStr = " (" + strings.Join(extras, ", ") + ")"
 		}
 
+		// Show first 8 chars of task UUID
+		shortID := t.ID[:8]
+
 		// Highlight overdue tasks in red
 		if isOverdue(t) {
-			fmt.Printf("  %s[ ] [%s] %s%s%s\n", colorRed, t.ID, t.Name, extraStr, colorReset)
+			fmt.Printf("  %s[ ] [%s] %s%s%s\n", colorRed, shortID, t.Name, extraStr, colorReset)
 		} else {
-			fmt.Printf("  [ ] [%s] %s%s\n", t.ID, t.Name, extraStr)
+			fmt.Printf("  [ ] [%s] %s%s\n", shortID, t.Name, extraStr)
 		}
 	}
 

--- a/commands/shortcut.go
+++ b/commands/shortcut.go
@@ -1,0 +1,46 @@
+package commands
+
+import "fmt"
+
+func init() {
+	Register(&Command{
+		Name:        "/shortcut",
+		Description: "Set a custom shortcut for a project",
+		Params: []Param{
+			{Name: "project_id", Type: ParamTypeString, Description: "The ID or current shortcut of the project", Required: true},
+			{Name: "new_shortcut", Type: ParamTypeString, Description: "The new shortcut (alphanumeric + hyphens, max 20 chars)", Required: true},
+		},
+		Handler: func(args []string) bool {
+			if len(args) < 2 {
+				fmt.Println("Usage: /shortcut <project-id> <new-shortcut>")
+				return false
+			}
+
+			projectRef := args[0]
+			newShortcut := args[1]
+
+			// Resolve the project ID
+			projectID, err := GetStore().ResolveProjectID(projectRef)
+			if err != nil {
+				fmt.Printf("Error: %v\n", err)
+				return false
+			}
+
+			// Get project for display
+			project, err := GetStore().GetProject(projectID)
+			if err != nil {
+				fmt.Printf("Error: %v\n", err)
+				return false
+			}
+
+			// Set the new shortcut
+			if err := GetStore().SetProjectShortcut(projectID, newShortcut); err != nil {
+				fmt.Printf("Error: %v\n", err)
+				return false
+			}
+
+			fmt.Printf("Set shortcut for %s to: %s\n", project.Name, newShortcut)
+			return false
+		},
+	})
+}

--- a/commands/task_test.go
+++ b/commands/task_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -39,6 +40,26 @@ func captureCommandOutput(t *testing.T, input string) string {
 	return output
 }
 
+// extractShortcut extracts the shortcut from project creation output
+func extractShortcut(output string) string {
+	re := regexp.MustCompile(`\(shortcut: ([a-f0-9]+)\)`)
+	matches := re.FindStringSubmatch(output)
+	if len(matches) >= 2 {
+		return matches[1]
+	}
+	return ""
+}
+
+// extractTaskID extracts the task ID from task creation output
+func extractTaskID(output string) string {
+	re := regexp.MustCompile(`\(ID: ([a-f0-9]+)\)`)
+	matches := re.FindStringSubmatch(output)
+	if len(matches) >= 2 {
+		return matches[1]
+	}
+	return ""
+}
+
 func TestProjectCommands(t *testing.T) {
 	cleanup := setupTestStore(t)
 	defer cleanup()
@@ -48,8 +69,12 @@ func TestProjectCommands(t *testing.T) {
 	if !strings.Contains(output, "Created project: My Test Project") {
 		t.Errorf("Expected project creation message, got: %s", output)
 	}
-	if !strings.Contains(output, "proj-1") {
-		t.Errorf("Expected project ID proj-1, got: %s", output)
+	if !strings.Contains(output, "shortcut:") {
+		t.Errorf("Expected shortcut in output, got: %s", output)
+	}
+	shortcut1 := extractShortcut(output)
+	if shortcut1 == "" {
+		t.Fatalf("Could not extract shortcut from: %s", output)
 	}
 
 	// List projects
@@ -57,19 +82,23 @@ func TestProjectCommands(t *testing.T) {
 	if !strings.Contains(output, "My Test Project") {
 		t.Errorf("Expected project in list, got: %s", output)
 	}
-	if !strings.Contains(output, "proj-1") {
-		t.Errorf("Expected project ID in list, got: %s", output)
+	if !strings.Contains(output, "["+shortcut1+"]") {
+		t.Errorf("Expected shortcut in list, got: %s", output)
 	}
 
 	// Create another project
 	output = captureCommandOutput(t, "/project Second Project")
-	if !strings.Contains(output, "proj-2") {
-		t.Errorf("Expected project ID proj-2, got: %s", output)
+	shortcut2 := extractShortcut(output)
+	if shortcut2 == "" {
+		t.Fatalf("Could not extract second shortcut from: %s", output)
+	}
+	if shortcut1 == shortcut2 {
+		t.Errorf("Shortcuts should be unique, got: %s and %s", shortcut1, shortcut2)
 	}
 
-	// Delete first project
-	output = captureCommandOutput(t, "/delproject proj-1")
-	if !strings.Contains(output, "Deleted project: proj-1") {
+	// Delete first project using shortcut
+	output = captureCommandOutput(t, "/delproject "+shortcut1)
+	if !strings.Contains(output, "Deleted project: My Test Project") {
 		t.Errorf("Expected deletion message, got: %s", output)
 	}
 
@@ -88,19 +117,21 @@ func TestTaskCommands(t *testing.T) {
 	defer cleanup()
 
 	// Create a project first
-	captureCommandOutput(t, "/project Test Project")
+	output := captureCommandOutput(t, "/project Test Project")
+	shortcut := extractShortcut(output)
 
-	// Create a task
-	output := captureCommandOutput(t, "/task proj-1 Buy groceries")
+	// Create a task using the shortcut
+	output = captureCommandOutput(t, "/task "+shortcut+" Buy groceries")
 	if !strings.Contains(output, "Created task: Buy groceries") {
 		t.Errorf("Expected task creation message, got: %s", output)
 	}
-	if !strings.Contains(output, "task-1") {
-		t.Errorf("Expected task ID task-1, got: %s", output)
+	taskID := extractTaskID(output)
+	if taskID == "" {
+		t.Fatalf("Could not extract task ID from: %s", output)
 	}
 
-	// List tasks
-	output = captureCommandOutput(t, "/tasks proj-1")
+	// List tasks using shortcut
+	output = captureCommandOutput(t, "/tasks "+shortcut)
 	if !strings.Contains(output, "Buy groceries") {
 		t.Errorf("Expected task in list, got: %s", output)
 	}
@@ -108,32 +139,32 @@ func TestTaskCommands(t *testing.T) {
 		t.Errorf("Expected unchecked status, got: %s", output)
 	}
 
-	// Mark as done
-	output = captureCommandOutput(t, "/done task-1")
-	if !strings.Contains(output, "Marked task task-1 as done") {
+	// Mark as done using task ID prefix
+	output = captureCommandOutput(t, "/done "+taskID)
+	if !strings.Contains(output, "Marked task Buy groceries as done") {
 		t.Errorf("Expected done message, got: %s", output)
 	}
 
 	// Verify done status in list
-	output = captureCommandOutput(t, "/tasks proj-1")
+	output = captureCommandOutput(t, "/tasks "+shortcut)
 	if !strings.Contains(output, "[✓]") {
 		t.Errorf("Expected checked status, got: %s", output)
 	}
 
 	// Mark as undone
-	output = captureCommandOutput(t, "/undone task-1")
-	if !strings.Contains(output, "Marked task task-1 as not done") {
+	output = captureCommandOutput(t, "/undone "+taskID)
+	if !strings.Contains(output, "Marked task Buy groceries as not done") {
 		t.Errorf("Expected undone message, got: %s", output)
 	}
 
 	// Delete task
-	output = captureCommandOutput(t, "/deltask task-1")
-	if !strings.Contains(output, "Deleted task: task-1") {
+	output = captureCommandOutput(t, "/deltask "+taskID)
+	if !strings.Contains(output, "Deleted task: Buy groceries") {
 		t.Errorf("Expected deletion message, got: %s", output)
 	}
 
 	// Verify task is gone
-	output = captureCommandOutput(t, "/tasks proj-1")
+	output = captureCommandOutput(t, "/tasks "+shortcut)
 	if strings.Contains(output, "Buy groceries") {
 		t.Errorf("Deleted task should not appear in list, got: %s", output)
 	}
@@ -144,29 +175,31 @@ func TestDueDateCommand(t *testing.T) {
 	defer cleanup()
 
 	// Setup: create project and task
-	captureCommandOutput(t, "/project Test Project")
-	captureCommandOutput(t, "/task proj-1 Important task")
+	output := captureCommandOutput(t, "/project Test Project")
+	shortcut := extractShortcut(output)
+	output = captureCommandOutput(t, "/task "+shortcut+" Important task")
+	taskID := extractTaskID(output)
 
 	// Set due date
-	output := captureCommandOutput(t, "/due task-1 2025-12-31")
-	if !strings.Contains(output, "Set due date for task task-1 to 2025-12-31") {
+	output = captureCommandOutput(t, "/due "+taskID+" 2025-12-31")
+	if !strings.Contains(output, "Set due date for task Important task to 2025-12-31") {
 		t.Errorf("Expected due date set message, got: %s", output)
 	}
 
 	// Verify due date in task list
-	output = captureCommandOutput(t, "/tasks proj-1")
+	output = captureCommandOutput(t, "/tasks "+shortcut)
 	if !strings.Contains(output, "due 2025-12-31") {
 		t.Errorf("Expected due date in task list, got: %s", output)
 	}
 
 	// Clear due date
-	output = captureCommandOutput(t, "/due task-1 none")
-	if !strings.Contains(output, "Cleared due date for task task-1") {
+	output = captureCommandOutput(t, "/due "+taskID+" none")
+	if !strings.Contains(output, "Cleared due date for task Important task") {
 		t.Errorf("Expected due date cleared message, got: %s", output)
 	}
 
 	// Verify due date is cleared (no parentheses means no extra info)
-	output = captureCommandOutput(t, "/tasks proj-1")
+	output = captureCommandOutput(t, "/tasks "+shortcut)
 	if strings.Contains(output, "due 2025-12-31") {
 		t.Errorf("Due date should be cleared, got: %s", output)
 	}
@@ -177,17 +210,19 @@ func TestDueDateInvalidFormat(t *testing.T) {
 	defer cleanup()
 
 	// Setup
-	captureCommandOutput(t, "/project Test Project")
-	captureCommandOutput(t, "/task proj-1 Test task")
+	output := captureCommandOutput(t, "/project Test Project")
+	shortcut := extractShortcut(output)
+	output = captureCommandOutput(t, "/task "+shortcut+" Test task")
+	taskID := extractTaskID(output)
 
 	// Try invalid date format
-	output := captureCommandOutput(t, "/due task-1 12-31-2025")
+	output = captureCommandOutput(t, "/due "+taskID+" 12-31-2025")
 	if !strings.Contains(output, "Invalid date format") {
 		t.Errorf("Expected invalid date format error, got: %s", output)
 	}
 
 	// Try another invalid format
-	output = captureCommandOutput(t, "/due task-1 tomorrow")
+	output = captureCommandOutput(t, "/due "+taskID+" tomorrow")
 	if !strings.Contains(output, "Invalid date format") {
 		t.Errorf("Expected invalid date format error, got: %s", output)
 	}
@@ -198,19 +233,21 @@ func TestDurationCommand(t *testing.T) {
 	defer cleanup()
 
 	// Setup
-	captureCommandOutput(t, "/project Test Project")
-	captureCommandOutput(t, "/task proj-1 Quick task")
+	output := captureCommandOutput(t, "/project Test Project")
+	shortcut := extractShortcut(output)
+	output = captureCommandOutput(t, "/task "+shortcut+" Quick task")
+	taskID := extractTaskID(output)
 
 	// Test all valid durations
 	validDurations := []string{"15m", "30m", "1h", "2h", "4h"}
 	for _, dur := range validDurations {
-		output := captureCommandOutput(t, "/duration task-1 "+dur)
-		if !strings.Contains(output, "Set duration for task task-1 to "+dur) {
+		output := captureCommandOutput(t, "/duration "+taskID+" "+dur)
+		if !strings.Contains(output, "Set duration for task Quick task to "+dur) {
 			t.Errorf("Expected duration set message for %s, got: %s", dur, output)
 		}
 
 		// Verify in task list
-		output = captureCommandOutput(t, "/tasks proj-1")
+		output = captureCommandOutput(t, "/tasks "+shortcut)
 		if !strings.Contains(output, "("+dur) {
 			t.Errorf("Expected duration %s in task list, got: %s", dur, output)
 		}
@@ -222,13 +259,15 @@ func TestDurationInvalid(t *testing.T) {
 	defer cleanup()
 
 	// Setup
-	captureCommandOutput(t, "/project Test Project")
-	captureCommandOutput(t, "/task proj-1 Test task")
+	output := captureCommandOutput(t, "/project Test Project")
+	shortcut := extractShortcut(output)
+	output = captureCommandOutput(t, "/task "+shortcut+" Test task")
+	taskID := extractTaskID(output)
 
 	// Try invalid durations
 	invalidDurations := []string{"10m", "45m", "3h", "1d", "invalid"}
 	for _, dur := range invalidDurations {
-		output := captureCommandOutput(t, "/duration task-1 "+dur)
+		output := captureCommandOutput(t, "/duration "+taskID+" "+dur)
 		if !strings.Contains(output, "Invalid duration") {
 			t.Errorf("Expected invalid duration error for %s, got: %s", dur, output)
 		}
@@ -240,15 +279,17 @@ func TestDueDateAndDurationTogether(t *testing.T) {
 	defer cleanup()
 
 	// Setup
-	captureCommandOutput(t, "/project Test Project")
-	captureCommandOutput(t, "/task proj-1 Full task")
+	output := captureCommandOutput(t, "/project Test Project")
+	shortcut := extractShortcut(output)
+	output = captureCommandOutput(t, "/task "+shortcut+" Full task")
+	taskID := extractTaskID(output)
 
 	// Set both duration and due date
-	captureCommandOutput(t, "/duration task-1 2h")
-	captureCommandOutput(t, "/due task-1 2025-06-15")
+	captureCommandOutput(t, "/duration "+taskID+" 2h")
+	captureCommandOutput(t, "/due "+taskID+" 2025-06-15")
 
 	// Verify both appear in task list
-	output := captureCommandOutput(t, "/tasks proj-1")
+	output = captureCommandOutput(t, "/tasks "+shortcut)
 	if !strings.Contains(output, "2h") {
 		t.Errorf("Expected duration in task list, got: %s", output)
 	}
@@ -266,7 +307,7 @@ func TestTaskInNonexistentProject(t *testing.T) {
 	defer cleanup()
 
 	// Try to create task in nonexistent project
-	output := captureCommandOutput(t, "/task proj-999 Orphan task")
+	output := captureCommandOutput(t, "/task nonexistent Orphan task")
 	if !strings.Contains(output, "project not found") {
 		t.Errorf("Expected project not found error, got: %s", output)
 	}
@@ -276,6 +317,12 @@ func TestCommandUsageMessages(t *testing.T) {
 	cleanup := setupTestStore(t)
 	defer cleanup()
 
+	// Create a project and task for tests that need valid IDs
+	output := captureCommandOutput(t, "/project Test Project")
+	shortcut := extractShortcut(output)
+	output = captureCommandOutput(t, "/task "+shortcut+" Test task")
+	taskID := extractTaskID(output)
+
 	tests := []struct {
 		command  string
 		expected string
@@ -283,16 +330,18 @@ func TestCommandUsageMessages(t *testing.T) {
 		{"/project", "Usage: /project <name>"},
 		{"/delproject", "Usage: /delproject <project-id>"},
 		{"/task", "Usage: /task <project-id> <task name>"},
-		{"/task proj-1", "Usage: /task <project-id> <task name>"},
+		{"/task " + shortcut, "Usage: /task <project-id> <task name>"},
 		{"/tasks", "Usage: /tasks <project-id>"},
 		{"/done", "Usage: /done <task-id>"},
 		{"/undone", "Usage: /undone <task-id>"},
 		{"/deltask", "Usage: /deltask <task-id>"},
 		{"/due", "Usage: /due <task-id>"},
-		{"/due task-1", "Usage: /due <task-id>"},
+		{"/due " + taskID, "Usage: /due <task-id>"},
 		{"/duration", "Usage: /duration <task-id>"},
-		{"/duration task-1", "Usage: /duration <task-id>"},
+		{"/duration " + taskID, "Usage: /duration <task-id>"},
 		{"/chat", "Usage: /chat <message>"},
+		{"/shortcut", "Usage: /shortcut <project-id> <new-shortcut>"},
+		{"/shortcut " + shortcut, "Usage: /shortcut <project-id> <new-shortcut>"},
 	}
 
 	for _, tc := range tests {
@@ -310,24 +359,26 @@ func TestDeleteProjectDeletesTasks(t *testing.T) {
 	defer cleanup()
 
 	// Create project with tasks
-	captureCommandOutput(t, "/project Project to delete")
-	captureCommandOutput(t, "/task proj-1 Task 1")
-	captureCommandOutput(t, "/task proj-1 Task 2")
+	output := captureCommandOutput(t, "/project Project to delete")
+	shortcut := extractShortcut(output)
+	output = captureCommandOutput(t, "/task "+shortcut+" Task 1")
+	taskID1 := extractTaskID(output)
+	captureCommandOutput(t, "/task "+shortcut+" Task 2")
 
 	// Verify tasks exist
-	output := captureCommandOutput(t, "/tasks proj-1")
+	output = captureCommandOutput(t, "/tasks "+shortcut)
 	if !strings.Contains(output, "Task 1") || !strings.Contains(output, "Task 2") {
 		t.Errorf("Expected tasks to exist before deletion, got: %s", output)
 	}
 
 	// Delete project
-	captureCommandOutput(t, "/delproject proj-1")
+	captureCommandOutput(t, "/delproject "+shortcut)
 
-	// Create a new project (will get proj-2)
-	captureCommandOutput(t, "/project New Project")
+	// Create a new project
+	output = captureCommandOutput(t, "/project New Project")
 
 	// The old task IDs should not exist
-	output = captureCommandOutput(t, "/done task-1")
+	output = captureCommandOutput(t, "/done "+taskID1)
 	if !strings.Contains(output, "task not found") {
 		t.Errorf("Expected task not found after project deletion, got: %s", output)
 	}
@@ -338,10 +389,11 @@ func TestEmptyProjectTaskList(t *testing.T) {
 	defer cleanup()
 
 	// Create empty project
-	captureCommandOutput(t, "/project Empty Project")
+	output := captureCommandOutput(t, "/project Empty Project")
+	shortcut := extractShortcut(output)
 
 	// List tasks
-	output := captureCommandOutput(t, "/tasks proj-1")
+	output = captureCommandOutput(t, "/tasks "+shortcut)
 	if !strings.Contains(output, "No tasks yet") {
 		t.Errorf("Expected no tasks message, got: %s", output)
 	}
@@ -367,5 +419,124 @@ func TestNoProjectsMessage(t *testing.T) {
 	output := captureCommandOutput(t, "/projects")
 	if !strings.Contains(output, "No projects yet") {
 		t.Errorf("Expected no projects message, got: %s", output)
+	}
+}
+
+func TestShortcutCommand(t *testing.T) {
+	cleanup := setupTestStore(t)
+	defer cleanup()
+
+	// Create a project
+	output := captureCommandOutput(t, "/project My Project")
+	shortcut := extractShortcut(output)
+
+	// Set a custom shortcut
+	output = captureCommandOutput(t, "/shortcut "+shortcut+" work")
+	if !strings.Contains(output, "Set shortcut for My Project to: work") {
+		t.Errorf("Expected shortcut set message, got: %s", output)
+	}
+
+	// Verify new shortcut appears in list
+	output = captureCommandOutput(t, "/projects")
+	if !strings.Contains(output, "[work]") {
+		t.Errorf("Expected new shortcut in list, got: %s", output)
+	}
+
+	// Create a task using new shortcut
+	output = captureCommandOutput(t, "/task work Test task")
+	if !strings.Contains(output, "Created task: Test task") {
+		t.Errorf("Expected task creation with shortcut, got: %s", output)
+	}
+
+	// List tasks using new shortcut
+	output = captureCommandOutput(t, "/tasks work")
+	if !strings.Contains(output, "Test task") {
+		t.Errorf("Expected task in list using shortcut, got: %s", output)
+	}
+}
+
+func TestShortcutValidation(t *testing.T) {
+	cleanup := setupTestStore(t)
+	defer cleanup()
+
+	// Create a project
+	output := captureCommandOutput(t, "/project My Project")
+	shortcut := extractShortcut(output)
+
+	// Try invalid shortcuts
+	invalidShortcuts := []string{
+		"abc!",                         // special char
+		"123456789012345678901",        // too long (21 chars)
+		"test@name",                    // @ symbol
+	}
+	for _, invalid := range invalidShortcuts {
+		output = captureCommandOutput(t, "/shortcut "+shortcut+" "+invalid)
+		if !strings.Contains(output, "invalid shortcut") {
+			t.Errorf("Expected invalid shortcut error for %q, got: %s", invalid, output)
+		}
+	}
+
+	// Valid shortcuts should work
+	validShortcuts := []string{
+		"a",           // single char
+		"abc123",      // alphanumeric
+		"my-project",  // with hyphen
+		"12345678901234567890", // 20 chars (max)
+	}
+	for _, valid := range validShortcuts {
+		output = captureCommandOutput(t, "/shortcut "+shortcut+" "+valid)
+		if strings.Contains(output, "Error") {
+			t.Errorf("Valid shortcut %q should work, got: %s", valid, output)
+		}
+		shortcut = valid // Update shortcut for next iteration
+	}
+}
+
+func TestShortcutConflict(t *testing.T) {
+	cleanup := setupTestStore(t)
+	defer cleanup()
+
+	// Create two projects
+	output := captureCommandOutput(t, "/project First Project")
+	shortcut1 := extractShortcut(output)
+	output = captureCommandOutput(t, "/project Second Project")
+	shortcut2 := extractShortcut(output)
+
+	// Set first project shortcut
+	captureCommandOutput(t, "/shortcut "+shortcut1+" work")
+
+	// Try to set same shortcut on second project
+	output = captureCommandOutput(t, "/shortcut "+shortcut2+" work")
+	if !strings.Contains(output, "shortcut already in use") {
+		t.Errorf("Expected shortcut conflict error, got: %s", output)
+	}
+}
+
+func TestUUIDPrefixMatching(t *testing.T) {
+	cleanup := setupTestStore(t)
+	defer cleanup()
+
+	// Create a project and task
+	output := captureCommandOutput(t, "/project Test Project")
+	shortcut := extractShortcut(output)
+	output = captureCommandOutput(t, "/task "+shortcut+" Test task")
+	taskID := extractTaskID(output)
+
+	// Task operations should work with the 8-char prefix
+	output = captureCommandOutput(t, "/done "+taskID)
+	if !strings.Contains(output, "Marked task Test task as done") {
+		t.Errorf("Expected done message with 8-char prefix, got: %s", output)
+	}
+
+	// 6-char prefix should also work (minimum)
+	output = captureCommandOutput(t, "/undone "+taskID[:6])
+	if !strings.Contains(output, "Marked task Test task as not done") {
+		t.Errorf("Expected undone message with 6-char prefix, got: %s", output)
+	}
+
+	// 5-char prefix should fail (too short)
+	output = captureCommandOutput(t, "/done "+taskID[:5])
+	if !strings.Contains(output, "task not found") {
+		t.Errorf("Expected task not found with 5-char prefix, got: %s", output)
 	}
 }

--- a/storage/json_test.go
+++ b/storage/json_test.go
@@ -1,0 +1,311 @@
+package storage
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMigration(t *testing.T) {
+	// Create a temp directory
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.json")
+
+	// Write old-style data directly to file
+	oldData := &jsonData{
+		Projects: []*Project{
+			{ID: "proj-1", Name: "Work", CreatedAt: time.Now()},
+			{ID: "proj-2", Name: "Personal", CreatedAt: time.Now()},
+		},
+		Tasks: []*Task{
+			{ID: "task-1", ProjectID: "proj-1", Name: "Task A", CreatedAt: time.Now()},
+			{ID: "task-2", ProjectID: "proj-1", Name: "Task B", CreatedAt: time.Now()},
+			{ID: "task-3", ProjectID: "proj-2", Name: "Task C", CreatedAt: time.Now()},
+		},
+		NextProjID: 3,
+		NextTaskID: 4,
+		Migrated:   false,
+	}
+
+	data, err := json.MarshalIndent(oldData, "", "  ")
+	if err != nil {
+		t.Fatalf("Failed to marshal old data: %v", err)
+	}
+	if err := os.WriteFile(dbPath, data, 0644); err != nil {
+		t.Fatalf("Failed to write old data: %v", err)
+	}
+
+	// Load the store, which should trigger migration
+	store, err := NewJSONStore(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	// Verify projects were migrated
+	projects, err := store.ListProjects()
+	if err != nil {
+		t.Fatalf("Failed to list projects: %v", err)
+	}
+	if len(projects) != 2 {
+		t.Errorf("Expected 2 projects, got %d", len(projects))
+	}
+
+	for _, p := range projects {
+		// IDs should be UUIDs (contain hyphens, not "proj-")
+		if strings.HasPrefix(p.ID, "proj-") {
+			t.Errorf("Project ID should be UUID, got: %s", p.ID)
+		}
+		if !strings.Contains(p.ID, "-") {
+			t.Errorf("Project ID should be UUID format, got: %s", p.ID)
+		}
+		// Shortcut should be set (first 8 chars of UUID)
+		if len(p.Shortcut) != 8 {
+			t.Errorf("Project shortcut should be 8 chars, got: %s", p.Shortcut)
+		}
+		if !strings.HasPrefix(p.ID, p.Shortcut) {
+			t.Errorf("Shortcut should be prefix of ID: %s vs %s", p.Shortcut, p.ID)
+		}
+	}
+
+	// Verify tasks were migrated
+	allTasks, err := store.ListAllTasks()
+	if err != nil {
+		t.Fatalf("Failed to list all tasks: %v", err)
+	}
+	if len(allTasks) != 3 {
+		t.Errorf("Expected 3 tasks, got %d", len(allTasks))
+	}
+
+	for _, task := range allTasks {
+		// Task IDs should be UUIDs
+		if strings.HasPrefix(task.ID, "task-") {
+			t.Errorf("Task ID should be UUID, got: %s", task.ID)
+		}
+		// ProjectID should reference UUID
+		if strings.HasPrefix(task.ProjectID, "proj-") {
+			t.Errorf("Task ProjectID should be UUID, got: %s", task.ProjectID)
+		}
+	}
+
+	// Verify project-task relationships are preserved
+	workProject := projects[0]
+	if workProject.Name != "Work" {
+		workProject = projects[1]
+	}
+	workTasks, err := store.ListTasks(workProject.ID)
+	if err != nil {
+		t.Fatalf("Failed to list work tasks: %v", err)
+	}
+	if len(workTasks) != 2 {
+		t.Errorf("Expected 2 tasks in Work project, got %d", len(workTasks))
+	}
+
+	// Verify Migrated flag is set
+	if !store.data.Migrated {
+		t.Error("Migrated flag should be true after migration")
+	}
+}
+
+func TestResolveProjectID(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.json")
+
+	store, err := NewJSONStore(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	// Create a project
+	project, err := store.CreateProject("Test Project")
+	if err != nil {
+		t.Fatalf("Failed to create project: %v", err)
+	}
+
+	// Resolve by exact UUID
+	resolved, err := store.ResolveProjectID(project.ID)
+	if err != nil {
+		t.Errorf("Failed to resolve by UUID: %v", err)
+	}
+	if resolved != project.ID {
+		t.Errorf("Expected %s, got %s", project.ID, resolved)
+	}
+
+	// Resolve by shortcut
+	resolved, err = store.ResolveProjectID(project.Shortcut)
+	if err != nil {
+		t.Errorf("Failed to resolve by shortcut: %v", err)
+	}
+	if resolved != project.ID {
+		t.Errorf("Expected %s, got %s", project.ID, resolved)
+	}
+
+	// Resolve by UUID prefix (6+ chars)
+	resolved, err = store.ResolveProjectID(project.ID[:6])
+	if err != nil {
+		t.Errorf("Failed to resolve by 6-char prefix: %v", err)
+	}
+	if resolved != project.ID {
+		t.Errorf("Expected %s, got %s", project.ID, resolved)
+	}
+
+	// Should fail with 5-char prefix
+	_, err = store.ResolveProjectID(project.ID[:5])
+	if err == nil {
+		t.Error("Should fail to resolve with 5-char prefix")
+	}
+
+	// Should fail with nonexistent ID
+	_, err = store.ResolveProjectID("nonexistent")
+	if err == nil {
+		t.Error("Should fail to resolve nonexistent project")
+	}
+}
+
+func TestResolveTaskID(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.json")
+
+	store, err := NewJSONStore(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	// Create project and task
+	project, err := store.CreateProject("Test Project")
+	if err != nil {
+		t.Fatalf("Failed to create project: %v", err)
+	}
+	task, err := store.CreateTask(project.ID, "Test Task")
+	if err != nil {
+		t.Fatalf("Failed to create task: %v", err)
+	}
+
+	// Resolve by exact UUID
+	resolved, err := store.ResolveTaskID(task.ID)
+	if err != nil {
+		t.Errorf("Failed to resolve by UUID: %v", err)
+	}
+	if resolved != task.ID {
+		t.Errorf("Expected %s, got %s", task.ID, resolved)
+	}
+
+	// Resolve by UUID prefix (8 chars - display format)
+	resolved, err = store.ResolveTaskID(task.ID[:8])
+	if err != nil {
+		t.Errorf("Failed to resolve by 8-char prefix: %v", err)
+	}
+	if resolved != task.ID {
+		t.Errorf("Expected %s, got %s", task.ID, resolved)
+	}
+
+	// Resolve by 6-char prefix (minimum)
+	resolved, err = store.ResolveTaskID(task.ID[:6])
+	if err != nil {
+		t.Errorf("Failed to resolve by 6-char prefix: %v", err)
+	}
+	if resolved != task.ID {
+		t.Errorf("Expected %s, got %s", task.ID, resolved)
+	}
+
+	// Should fail with 5-char prefix
+	_, err = store.ResolveTaskID(task.ID[:5])
+	if err == nil {
+		t.Error("Should fail to resolve with 5-char prefix")
+	}
+
+	// Should fail with nonexistent ID
+	_, err = store.ResolveTaskID("nonexistent")
+	if err == nil {
+		t.Error("Should fail to resolve nonexistent task")
+	}
+}
+
+func TestSetProjectShortcut(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.json")
+
+	store, err := NewJSONStore(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	// Create two projects
+	project1, err := store.CreateProject("Project 1")
+	if err != nil {
+		t.Fatalf("Failed to create project 1: %v", err)
+	}
+	project2, err := store.CreateProject("Project 2")
+	if err != nil {
+		t.Fatalf("Failed to create project 2: %v", err)
+	}
+
+	// Set custom shortcut
+	err = store.SetProjectShortcut(project1.ID, "work")
+	if err != nil {
+		t.Errorf("Failed to set shortcut: %v", err)
+	}
+
+	// Verify shortcut was set
+	updated, err := store.GetProject(project1.ID)
+	if err != nil {
+		t.Fatalf("Failed to get project: %v", err)
+	}
+	if updated.Shortcut != "work" {
+		t.Errorf("Expected shortcut 'work', got '%s'", updated.Shortcut)
+	}
+
+	// Should fail with conflicting shortcut
+	err = store.SetProjectShortcut(project2.ID, "work")
+	if err == nil {
+		t.Error("Should fail with conflicting shortcut")
+	}
+	if !strings.Contains(err.Error(), "already in use") {
+		t.Errorf("Expected 'already in use' error, got: %v", err)
+	}
+
+	// Should fail with invalid shortcut
+	err = store.SetProjectShortcut(project1.ID, "invalid!")
+	if err == nil {
+		t.Error("Should fail with invalid shortcut")
+	}
+	if !strings.Contains(err.Error(), "invalid shortcut") {
+		t.Errorf("Expected 'invalid shortcut' error, got: %v", err)
+	}
+
+	// Should fail with too long shortcut
+	err = store.SetProjectShortcut(project1.ID, "123456789012345678901")
+	if err == nil {
+		t.Error("Should fail with too long shortcut")
+	}
+}
+
+func TestUUIDGeneration(t *testing.T) {
+	// Generate multiple UUIDs and verify they're unique and properly formatted
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		uuid := generateUUID()
+
+		// Check format: 8-4-4-4-12 characters
+		parts := strings.Split(uuid, "-")
+		if len(parts) != 5 {
+			t.Errorf("UUID should have 5 parts, got %d: %s", len(parts), uuid)
+		}
+		if len(parts[0]) != 8 || len(parts[1]) != 4 || len(parts[2]) != 4 ||
+			len(parts[3]) != 4 || len(parts[4]) != 12 {
+			t.Errorf("UUID parts have wrong lengths: %s", uuid)
+		}
+
+		// Check uniqueness
+		if seen[uuid] {
+			t.Errorf("Duplicate UUID generated: %s", uuid)
+		}
+		seen[uuid] = true
+	}
+}

--- a/storage/store.go
+++ b/storage/store.go
@@ -10,6 +10,11 @@ type Store interface {
 	ListProjects() ([]*Project, error)
 	GetProject(id string) (*Project, error)
 	DeleteProject(id string) error
+	SetProjectShortcut(projectID, shortcut string) error
+
+	// ID resolution - resolves shortcuts/prefixes to full UUIDs
+	ResolveProjectID(idOrShortcut string) (string, error)
+	ResolveTaskID(idOrPrefix string) (string, error)
 
 	// Task operations
 	CreateTask(projectID, name string) (*Task, error)

--- a/storage/types.go
+++ b/storage/types.go
@@ -76,6 +76,7 @@ func TotalDuration(tasks []*Task) int {
 type Project struct {
 	ID        string    `json:"id"`
 	Name      string    `json:"name"`
+	Shortcut  string    `json:"shortcut,omitempty"`
 	CreatedAt time.Time `json:"created_at"`
 }
 


### PR DESCRIPTION
## Summary

- Replace sequential `proj-N`/`task-N` IDs with UUID v4 identifiers
- Add user-customizable shortcuts for projects (default: first 8 chars of UUID)
- Support flexible ID resolution: exact UUID, shortcut, or prefix match (min 6 chars)
- Automatic migration of existing databases on first load

## Changes

- **Storage layer**: UUID generation, resolution methods, shortcut management
- **New command**: `/shortcut <project-id> <new-shortcut>` to customize project shortcuts
- **Updated commands**: All project/task commands now use ID resolution and display short IDs
- **Migration**: Converts old `proj-N`/`task-N` IDs to UUIDs transparently

## Test plan

- [x] `go build` compiles successfully
- [x] `go test ./...` passes all tests
- [x] Create new project, verify UUID and auto-shortcut assigned
- [x] Run `/shortcut <id> custom` to set custom shortcut
- [x] Run `/projects` to see shortcut display
- [x] Create task, verify UUID assigned
- [x] Run `/tasks <shortcut>` to verify resolution works
- [x] Run `/done <partial-uuid>` to verify prefix matching
- [x] Test migration: old format data converts correctly

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)