### PR TITLE
Add chat context from direct commands and token usage tracking

### DIFF
--- a/commands/chat.go
+++ b/commands/chat.go
@@ -14,6 +14,56 @@ import (
 // chatHistory stores the conversation history for the /chat command
 var chatHistory []*llm.Message
 
+// Session usage tracking
+var (
+	sessionInputTokens  int64
+	sessionOutputTokens int64
+	sessionCost         float64
+	sessionPromptCount  int
+)
+
+// maxCommandContextEntries limits how many command context entries to keep
+const maxCommandContextEntries = 10
+
+// AddCommandContext adds a direct command and its output to the chat history
+// so the LLM has context about recent user actions.
+func AddCommandContext(command string, output string) {
+	contextMsg := fmt.Sprintf("User ran: %s\nOutput: %s", command, output)
+	chatHistory = append(chatHistory, &llm.Message{
+		Role:    "system",
+		Content: contextMsg,
+	})
+
+	// Trim old context entries to avoid unbounded growth
+	// Keep only the most recent command context entries
+	trimCommandContext()
+}
+
+// trimCommandContext removes old command context entries if there are too many
+func trimCommandContext() {
+	// Count system messages that are command context (not the initial system prompt)
+	var contextCount int
+	for _, msg := range chatHistory {
+		if msg.Role == "system" && strings.HasPrefix(msg.Content, "User ran:") {
+			contextCount++
+		}
+	}
+
+	// Remove oldest context entries if over limit
+	if contextCount > maxCommandContextEntries {
+		toRemove := contextCount - maxCommandContextEntries
+		var newHistory []*llm.Message
+		for _, msg := range chatHistory {
+			if toRemove > 0 && msg.Role == "system" && strings.HasPrefix(msg.Content, "User ran:") {
+				toRemove--
+				continue
+			}
+			newHistory = append(newHistory, msg)
+		}
+		chatHistory = newHistory
+	}
+}
+
 func init() {
 	Register(&Command{
 		Name:        "/clearchat",
@@ -22,6 +72,32 @@ func init() {
 		Handler: func(args []string) bool {
 			chatHistory = nil
 			fmt.Println("Chat history cleared.")
+			return false
+		},
+	})
+
+	Register(&Command{
+		Name:        "/usage",
+		Description: "Show session token usage and cost statistics",
+		Hidden:      true,
+		Handler: func(args []string) bool {
+			if sessionPromptCount == 0 {
+				fmt.Println("No chat usage in this session yet.")
+				return false
+			}
+
+			fmt.Println("Session Usage Statistics:")
+			fmt.Printf("  Prompts:       %d\n", sessionPromptCount)
+			fmt.Printf("  Input tokens:  %d\n", sessionInputTokens)
+			fmt.Printf("  Output tokens: %d\n", sessionOutputTokens)
+			fmt.Printf("  Total tokens:  %d\n", sessionInputTokens+sessionOutputTokens)
+			if sessionCost > 0 {
+				if sessionCost < 0.01 {
+					fmt.Printf("  Total cost:    $%.6f\n", sessionCost)
+				} else {
+					fmt.Printf("  Total cost:    $%.4f\n", sessionCost)
+				}
+			}
 			return false
 		},
 	})
@@ -78,9 +154,40 @@ func init() {
 			chatHistory = newHistory
 
 			fmt.Println(response.Text)
+
+			// Display usage statistics
+			printUsageStats(response)
 			return false
 		},
 	})
+}
+
+// printUsageStats displays token usage and cost information and updates session totals
+func printUsageStats(response *llm.Response) {
+	// Update session totals
+	sessionInputTokens += response.InputTokens
+	sessionOutputTokens += response.OutputTokens
+	sessionCost += response.Cost
+	sessionPromptCount++
+
+	// Only display if we have token data
+	if response.TokensUsed == 0 && response.InputTokens == 0 && response.OutputTokens == 0 {
+		return
+	}
+
+	fmt.Printf("\n[Tokens: %d in / %d out", response.InputTokens, response.OutputTokens)
+
+	// Display cost if available
+	if response.Cost > 0 {
+		// Format cost appropriately based on magnitude
+		if response.Cost < 0.01 {
+			fmt.Printf(" | Cost: $%.6f", response.Cost)
+		} else {
+			fmt.Printf(" | Cost: $%.4f", response.Cost)
+		}
+	}
+
+	fmt.Println("]")
 }
 
 // convertArgsToSlice converts Gemini function call arguments to a string slice

--- a/llm/types.go
+++ b/llm/types.go
@@ -4,6 +4,9 @@ type Response struct {
 	Text         string
 	FinishReason string
 	TokensUsed   int64
+	InputTokens  int64
+	OutputTokens int64
+	Cost         float64 // Cost in USD
 }
 
 type Config struct {

--- a/main.go
+++ b/main.go
@@ -94,9 +94,28 @@ func main() {
 			input = "/chat " + input
 		}
 
-		quit, err := commands.Execute(input)
-		if err != nil {
-			fmt.Printf("Error: %v\n", err)
+		// Check if this is a direct command (not /chat) that should be recorded in chat history
+		isDirectCommand := !strings.HasPrefix(strings.ToLower(input), "/chat")
+
+		var quit bool
+		var cmdErr error
+		if isDirectCommand {
+			// Execute with output capture for direct commands
+			var output string
+			quit, output, cmdErr = commands.ExecuteWithOutput(input)
+			if cmdErr == nil && output != "" {
+				// Print the output (since it was captured)
+				fmt.Println(output)
+				// Add to chat history for LLM context
+				commands.AddCommandContext(input, output)
+			}
+		} else {
+			// Execute normally for /chat commands
+			quit, cmdErr = commands.Execute(input)
+		}
+
+		if cmdErr != nil {
+			fmt.Printf("Error: %v\n", cmdErr)
 		}
 		if quit {
 			break


### PR DESCRIPTION
## Summary
- **Issue #36**: Direct commands now inject their output into chat history as system messages, enabling the LLM to reference recent actions (e.g., "update the due date for that task")
- **Issue #30**: Token usage and costs are now tracked and displayed after each chat response, with a `/usage` command for session statistics

## Changes
- `commands/chat.go`: Added `AddCommandContext()` function, session tracking variables, `/usage` command, and usage display after responses
- `commands/commands.go`: Added `ExecuteWithOutput()` to capture command output
- `llm/openrouter.go`: Parse input/output tokens and cost from OpenRouter response
- `llm/types.go`: Extended `Response` struct with `InputTokens`, `OutputTokens`, and `Cost` fields
- `main.go`: Direct commands now use output capture and inject context into chat history

## Test plan
- [x] Run `/task <project-id> Test Task` then `/chat Update the due date for that task to tomorrow` - LLM should know about the task
- [x] Run several chat prompts and verify token counts and costs display after each response
- [x] Run `/usage` to see session statistics
- [x] Run `/clearchat` and verify chat history is cleared

Closes #30, closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)