### PR TITLE
Improve chat UX: system prompt, immediate tool output, bug fixes

### DIFF
--- a/commands/chat.go
+++ b/commands/chat.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"twooms/llm"
 )
@@ -25,13 +26,52 @@ var (
 // maxCommandContextEntries limits how many command context entries to keep
 const maxCommandContextEntries = 10
 
+// commandContextPrefix identifies command context messages in history
+const commandContextPrefix = "[Command executed]"
+
+// getSystemPrompt returns the system prompt with today's date and tool-use instructions
+func getSystemPrompt() string {
+	today := time.Now().Format("2006-01-02") // YYYY-MM-DD format
+	weekday := time.Now().Weekday().String()
+
+	return fmt.Sprintf(`You are a helpful task management assistant for Twooms, a terminal-based task manager.
+
+TODAY'S DATE: %s (%s)
+
+IMPORTANT RULES:
+1. When a user refers to a project by NAME (not ID), FIRST call "projects" to find the ID, then use that ID.
+2. When a user refers to a task by NAME, FIRST call the listing tool to find the task's ID.
+3. NEVER ask the user for an ID. Always look it up using available tools.
+4. When users refer to "that task" or "the project I just created", use context from [Command executed] messages.
+5. When setting due dates: "today" = %s, "tomorrow" = the next day, etc.
+6. Tool outputs are ALREADY shown to the user. After using tools, just say "Done." or give a one-sentence summary. Do NOT repeat or list the tool output.
+7. Be concise since this is a terminal application.`, today, weekday, today)
+}
+
+// ensureSystemPrompt adds the system prompt if chat history is empty
+func ensureSystemPrompt() {
+	if len(chatHistory) == 0 {
+		chatHistory = append(chatHistory, &llm.Message{
+			Role:    "system",
+			Content: getSystemPrompt(),
+		})
+	}
+}
+
 // AddCommandContext adds a direct command and its output to the chat history
 // so the LLM has context about recent user actions.
 func AddCommandContext(command string, output string) {
-	contextMsg := fmt.Sprintf("User ran: %s\nOutput: %s", command, output)
+	ensureSystemPrompt()
+
+	contextMsg := fmt.Sprintf("%s %s\nResult: %s", commandContextPrefix, command, output)
 	chatHistory = append(chatHistory, &llm.Message{
-		Role:    "system",
+		Role:    "user",
 		Content: contextMsg,
+	})
+	// Add assistant acknowledgment to maintain proper conversation flow
+	chatHistory = append(chatHistory, &llm.Message{
+		Role:    "assistant",
+		Content: "Noted.",
 	})
 
 	// Trim old context entries to avoid unbounded growth
@@ -41,10 +81,10 @@ func AddCommandContext(command string, output string) {
 
 // trimCommandContext removes old command context entries if there are too many
 func trimCommandContext() {
-	// Count system messages that are command context (not the initial system prompt)
+	// Count messages that are command context
 	var contextCount int
 	for _, msg := range chatHistory {
-		if msg.Role == "system" && strings.HasPrefix(msg.Content, "User ran:") {
+		if strings.HasPrefix(msg.Content, commandContextPrefix) {
 			contextCount++
 		}
 	}
@@ -53,9 +93,15 @@ func trimCommandContext() {
 	if contextCount > maxCommandContextEntries {
 		toRemove := contextCount - maxCommandContextEntries
 		var newHistory []*llm.Message
+		skipNext := false
 		for _, msg := range chatHistory {
-			if toRemove > 0 && msg.Role == "system" && strings.HasPrefix(msg.Content, "User ran:") {
+			if skipNext {
+				skipNext = false
+				continue
+			}
+			if toRemove > 0 && strings.HasPrefix(msg.Content, commandContextPrefix) {
 				toRemove--
+				skipNext = true // Also skip the following "Noted." acknowledgment
 				continue
 			}
 			newHistory = append(newHistory, msg)
@@ -97,6 +143,8 @@ func init() {
 				} else {
 					fmt.Printf("  Total cost:    $%.4f\n", sessionCost)
 				}
+			} else {
+				fmt.Println("  Total cost:    no data")
 			}
 			return false
 		},
@@ -121,6 +169,9 @@ func init() {
 				return false
 			}
 
+			// Ensure system prompt is present
+			ensureSystemPrompt()
+
 			message := strings.Join(args, " ")
 			tools := GenerateToolDefinitions()
 
@@ -140,6 +191,11 @@ func init() {
 					Execute(cmdStr)
 				})
 
+				// Print output immediately so user sees progress
+				if output != "" {
+					fmt.Println(output)
+				}
+
 				return output
 			}
 
@@ -153,7 +209,10 @@ func init() {
 			// Update conversation history
 			chatHistory = newHistory
 
-			fmt.Println(response.Text)
+			// Only print response text if non-empty (tool outputs already printed)
+			if strings.TrimSpace(response.Text) != "" {
+				fmt.Println(response.Text)
+			}
 
 			// Display usage statistics
 			printUsageStats(response)
@@ -164,17 +223,15 @@ func init() {
 
 // printUsageStats displays token usage and cost information and updates session totals
 func printUsageStats(response *llm.Response) {
-	// Update session totals
-	sessionInputTokens += response.InputTokens
-	sessionOutputTokens += response.OutputTokens
-	sessionCost += response.Cost
-	sessionPromptCount++
-
-	// Only display if we have token data
-	if response.TokensUsed == 0 && response.InputTokens == 0 && response.OutputTokens == 0 {
-		return
+	// Only count if we have actual token data
+	if response.InputTokens > 0 || response.OutputTokens > 0 {
+		sessionInputTokens += response.InputTokens
+		sessionOutputTokens += response.OutputTokens
+		sessionCost += response.Cost
+		sessionPromptCount++
 	}
 
+	// Always show token info (helps debug silent failures)
 	fmt.Printf("\n[Tokens: %d in / %d out", response.InputTokens, response.OutputTokens)
 
 	// Display cost if available
@@ -185,6 +242,8 @@ func printUsageStats(response *llm.Response) {
 		} else {
 			fmt.Printf(" | Cost: $%.4f", response.Cost)
 		}
+	} else {
+		fmt.Printf(" | Cost: no data")
 	}
 
 	fmt.Println("]")
@@ -235,19 +294,22 @@ func captureOutput(fn func()) string {
 
 	// Redirect stdout to the pipe
 	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+
+	// Read in a goroutine to prevent pipe buffer deadlock
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		io.Copy(&buf, r)
+		close(done)
+	}()
 
 	// Run the function
 	fn()
 
-	// Close the write end of the pipe
+	// Close the write end of the pipe and wait for read to complete
 	w.Close()
-
-	// Restore stdout
-	os.Stdout = oldStdout
-
-	// Read captured output
-	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	<-done
 	r.Close()
 
 	return strings.TrimSpace(buf.String())

--- a/commands/schedule.go
+++ b/commands/schedule.go
@@ -201,8 +201,11 @@ func listTasksInRange(label string, start, end time.Time, projectID string, incl
 			extraStr = " (" + strings.Join(extras, ", ") + ")"
 		}
 
-		// Show first 8 chars of task UUID
-		shortID := t.ID[:8]
+		// Show first 8 chars of task UUID (or full ID if shorter)
+		shortID := t.ID
+		if len(t.ID) > 8 {
+			shortID = t.ID[:8]
+		}
 
 		// Highlight overdue tasks in red
 		if isOverdue(t) {

--- a/commands/task.go
+++ b/commands/task.go
@@ -38,7 +38,11 @@ func init() {
 				return false
 			}
 
-			fmt.Printf("Created task: %s (ID: %s)\n", task.Name, task.ID[:8])
+			shortID := task.ID
+			if len(task.ID) > 8 {
+				shortID = task.ID[:8]
+			}
+			fmt.Printf("Created task: %s (ID: %s)\n", task.Name, shortID)
 			return false
 		},
 	})
@@ -107,8 +111,11 @@ func init() {
 					extraStr = " (" + strings.Join(extras, ", ") + ")"
 				}
 
-				// Show first 8 chars of task UUID
-				shortID := t.ID[:8]
+				// Show first 8 chars of task UUID (or full ID if shorter)
+				shortID := t.ID
+				if len(t.ID) > 8 {
+					shortID = t.ID[:8]
+				}
 
 				// Highlight overdue tasks in red
 				if isOverdue(t) {


### PR DESCRIPTION
## Summary
- Add system prompt with today's date and tool-use instructions
- Print tool outputs immediately so users see progress during LLM tool calls
- Fix silent failures and improve error visibility

## Changes
- **commands/chat.go**: System prompt, immediate tool output printing, command context improvements
- **commands/commands.go**: Fix pipe buffer deadlock in ExecuteWithOutput
- **commands/schedule.go, task.go**: Fix panic when task ID < 8 chars (legacy IDs)
- **llm/openrouter.go**: Consolidate system prompt, add timeout, better error detection

## Test plan
- [x] Run `/task g test` then ask "mark that task done" - should use context
- [x] Ask "list my projects" - should see output immediately, then model summary
- [x] Verify legacy tasks with short IDs don't crash `/today` or `/tasks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)