### PR TITLE
Add confirmation prompts for destructive tool calls

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -33,6 +33,7 @@ type Command struct {
 	Handler     func(args []string) bool // returns true to quit
 	Params      []Param                  // parameter definitions for tool generation
 	Hidden      bool                     // if true, exclude from tool generation
+	Destructive bool                     // if true, requires confirmation when called via tool
 }
 
 var (
@@ -126,6 +127,14 @@ func List() []*Command {
 		cmds = append(cmds, cmd)
 	}
 	return cmds
+}
+
+// GetByName returns a command by name (with or without leading /)
+func GetByName(name string) *Command {
+	if !strings.HasPrefix(name, "/") {
+		name = "/" + name
+	}
+	return registry[strings.ToLower(name)]
 }
 
 // GenerateToolDefinitions creates Tool definitions from registered commands

--- a/commands/project.go
+++ b/commands/project.go
@@ -67,6 +67,7 @@ func init() {
 	Register(&Command{
 		Name:        "/delproject",
 		Description: "Delete a project and its tasks",
+		Destructive: true,
 		Params: []Param{
 			{Name: "project_id", Type: ParamTypeString, Description: "The ID of the project to delete", Required: true},
 		},

--- a/commands/task.go
+++ b/commands/task.go
@@ -214,6 +214,7 @@ func init() {
 	Register(&Command{
 		Name:        "/deltask",
 		Description: "Delete a task",
+		Destructive: true,
 		Params: []Param{
 			{Name: "task_id", Type: ParamTypeString, Description: "The ID of the task to delete", Required: true},
 		},


### PR DESCRIPTION
## Summary

- Add `Destructive` field to `Command` struct to mark commands requiring confirmation
- Mark `/delproject` and `/deltask` as destructive
- When LLM calls a destructive tool, prompt user with what will be deleted (e.g., "project 'Work' and its 3 task(s)")
- User must enter `y` or `yes` to proceed; any other input cancels the action

## Test plan

- [ ] Use `/chat delete my project` and verify confirmation prompt appears
- [ ] Enter `n` or press Enter and verify action is cancelled
- [ ] Enter `y` and verify deletion proceeds
- [ ] Test `/deltask` via chat similarly
- [ ] Verify direct commands (`/delproject`, `/deltask`) still work without confirmation

Closes #24

🤖 Generated with [Claude Code](https://claude.ai/claude-code)