### PR TITLE
Exclude destructive commands from LLM tools

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -33,6 +33,7 @@ type Command struct {
 	Handler     func(args []string) bool // returns true to quit
 	Params      []Param                  // parameter definitions for tool generation
 	Hidden      bool                     // if true, exclude from tool generation
+	Destructive bool                     // if true, exclude from tool generation (destructive actions)
 }
 
 var (
@@ -133,7 +134,7 @@ func GenerateToolDefinitions() []*llm.Tool {
 	var tools []*llm.Tool
 
 	for _, cmd := range registry {
-		if cmd.Hidden {
+		if cmd.Hidden || cmd.Destructive {
 			continue
 		}
 

--- a/commands/project.go
+++ b/commands/project.go
@@ -67,6 +67,7 @@ func init() {
 	Register(&Command{
 		Name:        "/delproject",
 		Description: "Delete a project and its tasks",
+		Destructive: true,
 		Params: []Param{
 			{Name: "project_id", Type: ParamTypeString, Description: "The ID of the project to delete", Required: true},
 		},

--- a/commands/task.go
+++ b/commands/task.go
@@ -214,6 +214,7 @@ func init() {
 	Register(&Command{
 		Name:        "/deltask",
 		Description: "Delete a task",
+		Destructive: true,
 		Params: []Param{
 			{Name: "task_id", Type: ParamTypeString, Description: "The ID of the task to delete", Required: true},
 		},


### PR DESCRIPTION
## Summary
- Add `Destructive` field to Command struct
- Exclude commands with `Destructive: true` from `GenerateToolDefinitions()`
- Mark `/delproject` and `/deltask` as destructive

This prevents the LLM from calling delete commands directly, avoiding accidental data loss.

Closes #40

## Test plan
- [x] Run `./twooms` and ask the LLM to delete a project/task
- [x] Verify the LLM cannot call delete commands (should say it can't do that)
- [ ] Verify `/delproject` and `/deltask` still work when called directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)