### PR TITLE
Add command shorthands

### DIFF
--- a/commands/chat.go
+++ b/commands/chat.go
@@ -114,6 +114,7 @@ func trimCommandContext() {
 func init() {
 	Register(&Command{
 		Name:        "/clearchat",
+		Shorthand:   "/cc",
 		Description: "Clear the chat conversation history",
 		Hidden:      true,
 		Handler: func(args []string) bool {
@@ -125,6 +126,7 @@ func init() {
 
 	Register(&Command{
 		Name:        "/usage",
+		Shorthand:   "/u",
 		Description: "Show session token usage and cost statistics",
 		Hidden:      true,
 		Handler: func(args []string) bool {
@@ -153,6 +155,7 @@ func init() {
 
 	Register(&Command{
 		Name:        "/chat",
+		Shorthand:   "/c",
 		Description: "Chat with the AI assistant",
 		Hidden:      true, // Exclude from tool generation
 		Params: []Param{

--- a/commands/debug.go
+++ b/commands/debug.go
@@ -7,6 +7,7 @@ var debugMode bool
 func init() {
 	Register(&Command{
 		Name:        "/debug",
+		Shorthand:   "/db",
 		Description: "Toggle debug mode for LLM interactions",
 		Hidden:      true,
 		Handler: func(args []string) bool {

--- a/commands/echo.go
+++ b/commands/echo.go
@@ -8,6 +8,7 @@ import (
 func init() {
 	Register(&Command{
 		Name:        "/echo",
+		Shorthand:   "/e",
 		Description: "Echo your message",
 		Hidden:      true,
 		Handler: func(args []string) bool {

--- a/commands/help.go
+++ b/commands/help.go
@@ -8,6 +8,7 @@ import (
 func init() {
 	Register(&Command{
 		Name:        "/help",
+		Shorthand:   "/h",
 		Description: "Show available commands",
 		Hidden:      true,
 		Handler: func(args []string) bool {
@@ -20,7 +21,11 @@ func init() {
 			})
 
 			for _, cmd := range cmds {
-				fmt.Printf("  %-15s - %s\n", cmd.Name, cmd.Description)
+				nameCol := cmd.Name
+				if cmd.Shorthand != "" {
+					nameCol = fmt.Sprintf("%s (%s)", cmd.Name, cmd.Shorthand)
+				}
+				fmt.Printf("  %-22s - %s\n", nameCol, cmd.Description)
 			}
 
 			return false

--- a/commands/project.go
+++ b/commands/project.go
@@ -8,6 +8,7 @@ import (
 func init() {
 	Register(&Command{
 		Name:        "/project",
+		Shorthand:   "/p",
 		Description: "Create a new project",
 		Params: []Param{
 			{Name: "name", Type: ParamTypeString, Description: "The name of the project to create", Required: true},
@@ -32,6 +33,7 @@ func init() {
 
 	Register(&Command{
 		Name:        "/projects",
+		Shorthand:   "/ps",
 		Description: "List all projects with their IDs. Use this to find a project's ID when you have the name.",
 		Handler: func(args []string) bool {
 			projects, err := GetStore().ListProjects()
@@ -66,6 +68,7 @@ func init() {
 
 	Register(&Command{
 		Name:        "/delproject",
+		Shorthand:   "/dp",
 		Description: "Delete a project and its tasks",
 		Destructive: true,
 		Params: []Param{

--- a/commands/quit.go
+++ b/commands/quit.go
@@ -5,6 +5,7 @@ import "fmt"
 func init() {
 	Register(&Command{
 		Name:        "/quit",
+		Shorthand:   "/q",
 		Description: "Exit Twooms",
 		Hidden:      true,
 		Handler: func(args []string) bool {

--- a/commands/schedule.go
+++ b/commands/schedule.go
@@ -27,6 +27,7 @@ func isOverdue(t *storage.Task) bool {
 func init() {
 	Register(&Command{
 		Name:        "/today",
+		Shorthand:   "/td",
 		Description: "List tasks due today (including overdue)",
 		Params: []Param{
 			{Name: "project_id", Type: ParamTypeString, Description: "Optional project ID to filter by", Required: false},
@@ -53,6 +54,7 @@ func init() {
 
 	Register(&Command{
 		Name:        "/tomorrow",
+		Shorthand:   "/tm",
 		Description: "List tasks due tomorrow",
 		Params: []Param{
 			{Name: "project_id", Type: ParamTypeString, Description: "Optional project ID to filter by", Required: false},
@@ -80,6 +82,7 @@ func init() {
 
 	Register(&Command{
 		Name:        "/week",
+		Shorthand:   "/w",
 		Description: "List tasks due this week (Monday through Sunday)",
 		Params: []Param{
 			{Name: "project_id", Type: ParamTypeString, Description: "Optional project ID to filter by", Required: false},

--- a/commands/shortcut.go
+++ b/commands/shortcut.go
@@ -5,6 +5,7 @@ import "fmt"
 func init() {
 	Register(&Command{
 		Name:        "/shortcut",
+		Shorthand:   "/sc",
 		Description: "Set a custom shortcut for a project",
 		Params: []Param{
 			{Name: "project_id", Type: ParamTypeString, Description: "The ID or current shortcut of the project", Required: true},

--- a/commands/task.go
+++ b/commands/task.go
@@ -11,6 +11,7 @@ import (
 func init() {
 	Register(&Command{
 		Name:        "/task",
+		Shorthand:   "/t",
 		Description: "Add a task to a project",
 		Params: []Param{
 			{Name: "project_id", Type: ParamTypeString, Description: "The ID of the project to add the task to", Required: true},
@@ -49,6 +50,7 @@ func init() {
 
 	Register(&Command{
 		Name:        "/tasks",
+		Shorthand:   "/ts",
 		Description: "List tasks in a project. Call 'projects' first if you only have the project name.",
 		Params: []Param{
 			{Name: "project_id", Type: ParamTypeString, Description: "The ID of the project to list tasks for", Required: true},
@@ -137,6 +139,7 @@ func init() {
 
 	Register(&Command{
 		Name:        "/done",
+		Shorthand:   "/d",
 		Description: "Mark a task as done",
 		Params: []Param{
 			{Name: "task_id", Type: ParamTypeString, Description: "The ID of the task to mark as done", Required: true},
@@ -175,6 +178,7 @@ func init() {
 
 	Register(&Command{
 		Name:        "/undone",
+		Shorthand:   "/ud",
 		Description: "Mark a task as not done",
 		Params: []Param{
 			{Name: "task_id", Type: ParamTypeString, Description: "The ID of the task to mark as not done", Required: true},
@@ -213,6 +217,7 @@ func init() {
 
 	Register(&Command{
 		Name:        "/deltask",
+		Shorthand:   "/dt",
 		Description: "Delete a task",
 		Destructive: true,
 		Params: []Param{
@@ -252,6 +257,7 @@ func init() {
 
 	Register(&Command{
 		Name:        "/due",
+		Shorthand:   "/du",
 		Description: "Set a task's due date",
 		Params: []Param{
 			{Name: "task_id", Type: ParamTypeString, Description: "The ID of the task", Required: true},
@@ -307,6 +313,7 @@ func init() {
 
 	Register(&Command{
 		Name:        "/duration",
+		Shorthand:   "/dur",
 		Description: "Set a task's duration",
 		Params: []Param{
 			{Name: "task_id", Type: ParamTypeString, Description: "The ID of the task", Required: true},


### PR DESCRIPTION
## Summary
- Adds a `Shorthand` field to the `Command` struct so every slash command has an abbreviated alias (e.g., `/p` for `/project`, `/t` for `/task`)
- Shorthands are registered in the same command registry and resolve transparently
- `/help` output now displays shorthands next to each command name
- Deduplicates `List()` and `GenerateToolDefinitions()` so shorthand aliases don't produce duplicate entries

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Run `/help` and verify shorthands display next to command names
- [x] Run `/p Test Project` and verify it behaves like `/project Test Project`
- [x] Run `/ts <id>` and verify it behaves like `/tasks <id>`

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)