### PR TITLE
Fix chat refusing to use project shortcuts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Twooms is a chat-based task manager that runs in the terminal. It's a Go CLI application with a command-based architecture.
 
+## Public-Facing Content
+
+When writing GitHub issues, PRs, commit messages, and any other public-facing content, always remove information specific to the user's own projects (project names, task names, personal data). Keep examples generic.
+
 ## Building and Running
 
 Build the project:

--- a/commands/chat.go
+++ b/commands/chat.go
@@ -39,14 +39,16 @@ func getSystemPrompt() string {
 TODAY'S DATE: %s (%s)
 
 IMPORTANT RULES:
-1. When a user refers to a project by NAME (not ID), FIRST call "projects" to find the ID, then use that ID.
-2. When a user refers to a task by NAME, FIRST call the listing tool to find the task's ID.
-3. NEVER ask the user for an ID. Always look it up using available tools.
-4. When users refer to "that task" or "the project I just created", use context from [Command executed] messages.
-5. When setting due dates: "today" = %s, "tomorrow" = the next day, etc.
-6. Tool outputs are ALREADY shown to the user. After using tools, just say "Done." or give a one-sentence summary. Do NOT repeat or list the tool output.
-7. Be concise since this is a terminal application.
-8. When creating a task and setting its properties (duration, due date), call "task" FIRST and wait for the result to get the task ID, then call duration/due with that ID. Do NOT call them in parallel.`, today, weekday, today)
+1. When a user refers to a project by NAME (not ID), FIRST call "projects" to find its shortcut, then use that shortcut as the project_id.
+2. Projects have SHORTCUTS (shown in brackets in the projects list, e.g. [a], [work]). Always use the shortcut as the project_id parameter when calling tools like "task" or "tasks". Shortcuts are valid project IDs.
+3. When a user refers to a task by NAME, FIRST call the listing tool to find the task's ID.
+4. NEVER ask the user for an ID. Always look it up using available tools.
+5. When users refer to "that task" or "the project I just created", use context from [Command executed] messages.
+6. When setting due dates: "today" = %s, "tomorrow" = the next day, etc.
+7. Tool outputs are ALREADY shown to the user. After using tools, just say "Done." or give a one-sentence summary. Do NOT repeat or list the tool output.
+8. Be concise since this is a terminal application.
+9. When creating a task and setting its properties (duration, due date), call "task" FIRST and wait for the result to get the task ID, then call duration/due with that ID. Do NOT call them in parallel.
+10. ALWAYS attempt tool calls when asked to perform actions. Never refuse by saying a project or task doesn't exist without first trying the tool call.`, today, weekday, today)
 }
 
 // ensureSystemPrompt adds the system prompt if chat history is empty

--- a/commands/project.go
+++ b/commands/project.go
@@ -72,7 +72,7 @@ func init() {
 		Description: "Delete a project and its tasks",
 		Destructive: true,
 		Params: []Param{
-			{Name: "project_id", Type: ParamTypeString, Description: "The ID of the project to delete", Required: true},
+			{Name: "project_id", Type: ParamTypeString, Description: "The ID or shortcut of the project to delete", Required: true},
 		},
 		Handler: func(args []string) bool {
 			if len(args) == 0 {

--- a/commands/task.go
+++ b/commands/task.go
@@ -14,7 +14,7 @@ func init() {
 		Shorthand:   "/t",
 		Description: "Add a task to a project",
 		Params: []Param{
-			{Name: "project_id", Type: ParamTypeString, Description: "The ID of the project to add the task to", Required: true},
+			{Name: "project_id", Type: ParamTypeString, Description: "The ID or shortcut of the project to add the task to", Required: true},
 			{Name: "task_name", Type: ParamTypeString, Description: "The name of the task to create", Required: true},
 		},
 		Handler: func(args []string) bool {
@@ -53,7 +53,7 @@ func init() {
 		Shorthand:   "/ts",
 		Description: "List tasks in a project. Call 'projects' first if you only have the project name.",
 		Params: []Param{
-			{Name: "project_id", Type: ParamTypeString, Description: "The ID of the project to list tasks for", Required: true},
+			{Name: "project_id", Type: ParamTypeString, Description: "The ID or shortcut of the project to list tasks for", Required: true},
 		},
 		Handler: func(args []string) bool {
 			if len(args) == 0 {

--- a/llm/openrouter.go
+++ b/llm/openrouter.go
@@ -198,6 +198,12 @@ func (c *OpenRouterClient) ChatWithTools(ctx context.Context, message string, hi
 			finalContent = "Done."
 		}
 
+		// If we got no content at all (no text, no tool calls), the API likely
+		// returned an empty or malformed response
+		if finalContent == "" && len(toolResults) == 0 && totalInputTokens == 0 {
+			return nil, newHistory, fmt.Errorf("received empty response from API (no content or tool calls)")
+		}
+
 		assistantMsg := &Message{
 			Role:    "assistant",
 			Content: finalContent,


### PR DESCRIPTION
## Summary
- The `/chat` LLM was refusing to use project shortcuts as project IDs when making tool calls, repeatedly saying "project doesn't exist" even when the user provided a valid shortcut
- Updated tool param descriptions to indicate shortcuts are valid project identifiers
- Updated the system prompt to explain how shortcuts work and to always attempt tool calls
- Added error handling for empty/zero-token API responses that were failing silently

## Test plan
- [x] Run `go test ./...` — all tests should pass
- [x] Start the app, create a project, note its shortcut
- [x] Use `/chat` to ask it to create a task in that project by name (e.g. "create a task called Test in my Project project") — it should call `projects` first, then use the shortcut to create the task
- [x] Use `/chat` to ask it to create a task using the shortcut directly (e.g. "create a task called Test in project a") — it should use the shortcut without complaint
- [x] Use `/chat` to ask it to create multiple tasks at once — it should handle them sequentially without refusing

🤖 Generated with [Claude Code](https://claude.com/claude-code)